### PR TITLE
Ester evolution for nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     string(CONCAT CMAKE_Fortran_FLAGS
         "-g -O3"
+        " -fallow-argument-mismatch -fallow-invalid-boz"
         " -fno-align-commons -fdefault-real-8 -fdefault-double-8"
         " -ffixed-line-length-none -O -w -fd-lines-as-comments")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
@@ -42,6 +43,18 @@ find_package(LAPACK REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(SWIG REQUIRED)
 find_package(PythonInterp REQUIRED)
+
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}"
+    -c "import numpy; print(numpy.get_include())"
+    OUTPUT_VARIABLE NUMPY_INCLUDE_DIRS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+include_directories(${NUMPY_INCLUDE_DIRS})
+#include(CMakePrintHelpers)
+#cmake_print_variables(PYTHON_INCLUDE_DIRS)
+#cmake_print_variables(NUMPY_INCLUDE_DIRS)
+
 find_package(HDF5 COMPONENTS CXX)
 # find_package(VTK 6.3)
 
@@ -70,6 +83,7 @@ include_directories(src/include)
 include_directories(src/graphics)
 include_directories(${PYTHON_INCLUDE_DIRS})
 set(LIBS "${LIBS};${PYTHON_LIBRARIES}")
+
 
 add_definitions(-DWITH_CMAKE)
 add_definitions(-DVERSION="${PROJECT_VERSION}")

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -18,7 +18,7 @@ void sigfpe_handler(int) {
 void enable_sigfpe() {
     // FE_DIVBYZERO | FE_INEXACT | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW 
     // FE_ALL_EXCEPT
-    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+    // feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
     signal(SIGFPE, sigfpe_handler);
 }
 

--- a/src/utils/stack.cpp
+++ b/src/utils/stack.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <unistd.h>
 #include <iomanip>
+#include <cstdint>
 
 inline std::string addr2str(uintptr_t addr) {
     std::ostringstream stream;

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -68,6 +68,8 @@ add_library(freeeos SHARED
     freeeos/round_ln.f
     freeeos/tau_calc.f
     freeeos/version.f)
+  target_link_libraries(freeeos 
+	  ${BLAS_LIBRARIES})
 
 add_library(opint SHARED
     houdek/v9/lib/condux_ad.f


### PR DESCRIPTION
Minor patches to make ester's evolution branch work with nix env. Tested on linux(ubuntu) and macos(M1).